### PR TITLE
Create project.code-workspace

### DIFF
--- a/.vscode/project.code-workspace
+++ b/.vscode/project.code-workspace
@@ -1,0 +1,55 @@
+{
+    "folders": [
+        {
+            "name": "Root",
+            "path": "../"
+        },
+        {
+            "name": "packages/foobar-package",
+            "path": "../packages/foobar-package"
+        },
+        {
+            "name": "packages/shared-models",
+            "path": "../packages/shared-models"
+        },
+        {
+            "name": "packages/shared-types",
+            "path": "../packages/shared-types"
+        },
+        {
+            "name": "packages/shared-utils",
+            "path": "../packages/shared-utils"
+        },
+        {
+            "name": "services/auth",
+            "path": "../services/auth"
+        },
+        {
+            "name": "services/foobar-service",
+            "path": "../services/foobar-service"
+        },
+        {
+            "name": "services/gateway",
+            "path": "../services/gateway"
+        },
+        {
+            "name": "services/matching-engine",
+            "path": "../services/matching-engine"
+        },
+        {
+            "name": "services/user-api",
+            "path": "../services/user-api"
+        },
+        {
+            "name": "services/web-ui",
+            "path": "../services/web-ui"
+        },
+    ],
+    "settings": {
+        "files.exclude": {
+            "node_modules/": true,
+            "packages/": true,
+            "services/": true,
+        },
+    }
+}


### PR DESCRIPTION
Makes working with mono-repo easier in VSCode.

Should now be able to open the mono-repo as a workspace in VSCode and develop individual packages and services.