### PR TITLE
Fix status codes

### DIFF
--- a/packages/shared-utils/jwtMiddleware.ts
+++ b/packages/shared-utils/jwtMiddleware.ts
@@ -1,5 +1,6 @@
 import { type Context, type Next } from "hono";
 import { verify } from "hono/jwt";
+import { handleError } from ".";
 
 // JWT Middleware
 export const jwtAuthorize = async (c: Context, next: Next) => {
@@ -21,6 +22,6 @@ export const jwtAuthorize = async (c: Context, next: Next) => {
 
     return await next();
   } catch (error) {
-    return c.json({ success: false, data: { error: "Invalid token" } }, 401);
+    return handleError(c, error, "An unknown error has occured with token authorization", 500);
   }
 };

--- a/packages/shared-utils/jwtMiddleware.ts
+++ b/packages/shared-utils/jwtMiddleware.ts
@@ -22,6 +22,6 @@ export const jwtAuthorize = async (c: Context, next: Next) => {
 
     return await next();
   } catch (error) {
-    return handleError(c, error, "An unknown error has occured with token authorization", 500);
+    return handleError(c, error, "An unknown error has occured with token authorization");
   }
 };

--- a/packages/shared-utils/jwtMiddleware.ts
+++ b/packages/shared-utils/jwtMiddleware.ts
@@ -8,14 +8,14 @@ export const jwtAuthorize = async (c: Context, next: Next) => {
     const tokenToVerify = c.req.header("token");
 
     if (!tokenToVerify) {
-      return c.json({ success: false, data: { error: "Token not included" } }, 401);
+      return handleError(c, new Error("Token not included"), "Token not included", 401);
     }
 
     let payload = null;
     try {
       payload = await verify(tokenToVerify, Bun.env.JWT_SECRET || "secret");
     } catch (err) {
-      return c.json({ success: false, data: { error: "Invalid credentials" } }, 401);
+      return handleError(c, new Error("Invalid token included"), "Invalid token included", 401);
     }
 
     c.set("user", payload);

--- a/services/auth/package.json
+++ b/services/auth/package.json
@@ -13,7 +13,7 @@
     "typescript": "^5.0.0"
   },
   "dependencies": {
-    "hono": "^4.6.18",
+    "hono": "4.6.19",
     "redis": "^4.7.0",
     "redis-om": "^0.4.7",
     "shared-models": "workspace:*",

--- a/services/auth/src/controllers/authController.ts
+++ b/services/auth/src/controllers/authController.ts
@@ -5,7 +5,7 @@ import { handleError } from "shared-utils";
 
 const controller = {
   register: async (c: Context) => {
-    const { user_name, password, name }: RegisterRequest = await c.req.json();
+    const { user_name, password, name }: Partial<RegisterRequest> = await c.req.json();
 
     if (!user_name || !password || !name) {
       return handleError(
@@ -25,7 +25,7 @@ const controller = {
   },
 
   login: async (c: Context) => {
-    const { user_name, password }: LoginRequest = await c.req.json();
+    const { user_name, password }: Partial<LoginRequest> = await c.req.json();
 
     if (!user_name || !password) {
       return handleError(
@@ -40,7 +40,7 @@ const controller = {
       const token = await service.login(user_name, password);
       return c.json({ success: true, data: token });
     } catch (error) {
-      return handleError(c, error, "An unknown error has occured with login");
+      return handleError(c, error, "Incorrect username and/or password", 400);
     }
   },
 };

--- a/services/auth/src/controllers/authController.ts
+++ b/services/auth/src/controllers/authController.ts
@@ -1,17 +1,17 @@
 import service from "../services/authService";
 import type { Context } from "hono";
 import type { RegisterRequest, LoginRequest } from "shared-types/dtos/auth/auth";
+import { handleError } from "shared-utils";
 
 const controller = {
   register: async (c: Context) => {
     const { user_name, password, name }: RegisterRequest = await c.req.json();
 
     if (!user_name || !password || !name) {
-      return c.json(
-        {
-          success: false,
-          data: { error: "Username, password, and name are required" },
-        },
+      return handleError(
+        c,
+        new Error("Invalid request body: Username, password, and name are required"),
+        "Username, password, and name are required",
         400
       );
     }
@@ -20,7 +20,7 @@ const controller = {
       await service.register(user_name, password, name);
       return c.json({ success: true, data: null });
     } catch (error) {
-      return c.json(handleError(error), 400);
+      return handleError(c, error, "An unknown error has occured with registration", 500);
     }
   },
 
@@ -28,11 +28,10 @@ const controller = {
     const { user_name, password }: LoginRequest = await c.req.json();
 
     if (!user_name || !password) {
-      return c.json(
-        {
-          success: false,
-          data: { error: "Username and password are required" },
-        },
+      return handleError(
+        c,
+        new Error("Invalid request body: Username and password are required"),
+        "Username and password are required",
         400
       );
     }
@@ -41,16 +40,9 @@ const controller = {
       const token = await service.login(user_name, password);
       return c.json({ success: true, data: token });
     } catch (error) {
-      return c.json(handleError(error), 400);
+      return handleError(c, error, "An unknown error has occured with login", 500);
     }
   },
-};
-
-const handleError = (error: unknown) => {
-  if (error instanceof Error) {
-    return { success: false, data: { error: error.message } };
-  }
-  return { success: false, data: { error: "An unknown error has occurred" } };
 };
 
 export default controller;

--- a/services/auth/src/controllers/authController.ts
+++ b/services/auth/src/controllers/authController.ts
@@ -20,7 +20,7 @@ const controller = {
       await service.register(user_name, password, name);
       return c.json({ success: true, data: null });
     } catch (error) {
-      return handleError(c, error, "An unknown error has occured with registration", 500);
+      return handleError(c, error, "An unknown error has occured with registration");
     }
   },
 
@@ -40,7 +40,7 @@ const controller = {
       const token = await service.login(user_name, password);
       return c.json({ success: true, data: token });
     } catch (error) {
-      return handleError(c, error, "An unknown error has occured with login", 500);
+      return handleError(c, error, "An unknown error has occured with login");
     }
   },
 };

--- a/services/auth/src/services/authService.ts
+++ b/services/auth/src/services/authService.ts
@@ -1,5 +1,4 @@
 import { sign } from "hono/jwt";
-import bcrypt from "bcrypt";
 import { userSchema, type User } from "shared-models/redisSchema";
 import { RedisInstance } from "shared-models/RedisInstance";
 import { Repository } from "redis-om";

--- a/services/order/src/controllers/orderController.ts
+++ b/services/order/src/controllers/orderController.ts
@@ -7,7 +7,12 @@ const controller = {
     const { stock_id, quantity, price, user_name } = await c.req.json();
 
     if (!stock_id || !quantity || !price || !user_name) {
-      return c.json({ success: false, data: { error: "Missing required parameters" } }, 400);
+      return handleError(
+        c,
+        new Error("Invalid request body: Missing required parameters for limit sell"),
+        "Missing required parameters for limit sell",
+        400
+      );
     }
 
     try {
@@ -32,8 +37,6 @@ const controller = {
   getStockPrices: async (c: Context) => {
     try {
       const data = await service.getStockPrices();
-
-      // REVIEW: lexiographic ordering of stocks?
       return c.json({ success: true, data }, 200);
     } catch (error) {
       return handleError(c, error, "An unknown error has occurred while fetching stock prices");
@@ -44,14 +47,19 @@ const controller = {
     const { stock_tx_id, user_name } = await c.req.json();
 
     if (!stock_tx_id) {
-      return c.json({ success: false, data: { error: "Missing stock_tx_id" } }, 400);
+      return handleError(
+        c,
+        new Error("Invalid request body: Missing stock_tx_id"),
+        "Missing stock_tx_id",
+        400
+      );
     }
 
     try {
       await service.cancelStockTransaction(stock_tx_id, user_name);
       return c.json({ success: true, data: null }, 200);
     } catch (error) {
-      return handleError(c, error, "An unknown error has occurred while canceling transaction");
+      return handleError(c, error, "An unknown error has occurred while cancelling transaction");
     }
   },
 

--- a/services/user-api/src/controllers/engineController.ts
+++ b/services/user-api/src/controllers/engineController.ts
@@ -61,7 +61,7 @@ const engineController = {
       if (response.success) {
         return c.json({ success: true, data: null });
       } else {
-        return handleError(c, new Error("Failed to place order"), "Failed to place order", 400);
+        return handleError(c, new Error("Failed to place order"), "Failed to place order", 500);
       }
     }
   },
@@ -79,7 +79,7 @@ const engineController = {
     if (response.success) {
       return c.json({ success: true, data: null });
     } else {
-      return handleError(c, new Error("Failed to cancel order"), "Failed to cancel order", 400);
+      return handleError(c, new Error("Failed to cancel order"), "Failed to cancel order", 500);
     }
   },
 };

--- a/services/user-api/src/controllers/engineController.ts
+++ b/services/user-api/src/controllers/engineController.ts
@@ -26,7 +26,7 @@ const engineController = {
           c,
           new Error("Only market buy orders are supported"),
           "Invalid order type",
-          422
+          400
         );
       }
       const response = await makeInternalRequest<PlaceMarketBuyRequest, PlaceMarketBuyResponse>({
@@ -47,7 +47,7 @@ const engineController = {
           c,
           new Error("Only limit sell orders are supported"),
           "Invalid order type",
-          422
+          400
         );
       }
       const response = await makeInternalRequest<PlaceLimitSellRequest, PlaceLimitSellResponse>({

--- a/services/user-api/src/controllers/engineController.ts
+++ b/services/user-api/src/controllers/engineController.ts
@@ -1,3 +1,4 @@
+import type { ContentfulStatusCode } from "hono/utils/http-status";
 import {
   type PlaceLimitSellRequest,
   type PlaceLimitSellResponse,
@@ -39,7 +40,12 @@ const engineController = {
       if (response.success) {
         return c.json({ success: true, data: null });
       } else {
-        return handleError(c, new Error("Failed to place order"), "Failed to place order", 400);
+        return handleError(
+          c,
+          new Error("Failed to place order"),
+          "Failed to place order",
+          response.status == 400 ? 400 : 500
+        );
       }
     } else {
       if (orderType !== ORDER_TYPE.LIMIT) {
@@ -61,7 +67,12 @@ const engineController = {
       if (response.success) {
         return c.json({ success: true, data: null });
       } else {
-        return handleError(c, new Error("Failed to place order"), "Failed to place order", 500);
+        return handleError(
+          c,
+          new Error("Failed to place order"),
+          "Failed to place order",
+          response.status == 400 ? 400 : 500
+        );
       }
     }
   },
@@ -79,7 +90,12 @@ const engineController = {
     if (response.success) {
       return c.json({ success: true, data: null });
     } else {
-      return handleError(c, new Error("Failed to cancel order"), "Failed to cancel order", 500);
+      return handleError(
+        c,
+        new Error("Failed to cancel order"),
+        "Failed to cancel order",
+        response.status == 400 ? 400 : 500
+      );
     }
   },
 };

--- a/services/user-api/src/controllers/setupController.ts
+++ b/services/user-api/src/controllers/setupController.ts
@@ -11,7 +11,7 @@ const setupController = {
       const stock_id = await stockService.createStock(stock_name);
       return c.json({ success: true, data: { stock_id } });
     } catch (e) {
-      return handleError(c, e, "Failed to create stock", 400);
+      return handleError(c, e, "Failed to create stock", 500);
     }
   },
   addStockToUserRequest: async (c: ContextWithUser<WrappedInput<AddStockToUserRequest>>) => {

--- a/services/user-api/src/controllers/stockController.ts
+++ b/services/user-api/src/controllers/stockController.ts
@@ -34,7 +34,7 @@ const stockController = {
       });
       return c.json({ success: true, data: sortedData });
     } catch (e) {
-      return handleError(c, e, "Failed to get stock prices", 400);
+      return handleError(c, e, "Failed to get stock prices", 500);
     }
   },
   getStockPortfolio: async (c: ContextWithUser) => {
@@ -60,7 +60,7 @@ const stockController = {
         });
       return c.json({ success: true, data: userStocksOwned });
     } catch (e) {
-      return handleError(c, e, "Failed to get stock portfolio", 400);
+      return handleError(c, e, "Failed to get stock portfolio", 500);
     }
   },
   getStockTransactions: async (c: ContextWithUser) => {
@@ -83,7 +83,7 @@ const stockController = {
         .sort((t1, t2) => t1.time_stamp.localeCompare(t2.time_stamp));
       return c.json({ success: true, data: userStockTransactionsFormatted });
     } catch (e) {
-      return handleError(c, e, "Failed to get stock transactions", 400);
+      return handleError(c, e, "Failed to get stock transactions", 500);
     }
   },
 };

--- a/services/user-api/src/controllers/walletController.ts
+++ b/services/user-api/src/controllers/walletController.ts
@@ -11,7 +11,7 @@ const walletController = {
       const user = await userService.getUserFromId(username);
       return c.json({ success: true, data: { balance: user.wallet_balance } });
     } catch (e) {
-      return handleError(c, e, "Failed to get wallet balance", 400);
+      return handleError(c, e, "Failed to get wallet balance", 500);
     }
   },
   getWalletTransactions: async (c: ContextWithUser) => {
@@ -30,7 +30,7 @@ const walletController = {
 
       return c.json({ success: true, data: userWalletTransactionsFormatted });
     } catch (e) {
-      return handleError(c, e, "Failed to get wallet transactions", 400);
+      return handleError(c, e, "Failed to get wallet transactions", 500);
     }
   },
   addMoneyToWallet: async (c: ContextWithUser<WrappedInput<AddMoneyToWalletRequest>>) => {
@@ -40,7 +40,7 @@ const walletController = {
       await walletService.addMoneyToWallet(username, amount);
       return c.json({ success: true, data: null });
     } catch (e) {
-      return handleError(c, e, "Failed to add money to wallet", 400);
+      return handleError(c, e, "Failed to add money to wallet", 500);
     }
   },
 };

--- a/services/user-api/src/controllers/walletController.ts
+++ b/services/user-api/src/controllers/walletController.ts
@@ -36,11 +36,20 @@ const walletController = {
   addMoneyToWallet: async (c: ContextWithUser<WrappedInput<AddMoneyToWalletRequest>>) => {
     const { username } = c.get("user");
     const { amount } = c.req.valid("json");
+
+    if (amount < 0) {
+      return handleError(
+        c,
+        new Error("A negative value cannot be added to the wallet"),
+        "A negative value cannot be added to the wallet",
+        400
+      );
+    }
     try {
       await walletService.addMoneyToWallet(username, amount);
       return c.json({ success: true, data: null });
     } catch (e) {
-      return handleError(c, e, "Failed to add money to wallet", 400);
+      return handleError(c, e, "Failed to add money to wallet", 500);
     }
   },
 };

--- a/services/user-api/src/controllers/walletController.ts
+++ b/services/user-api/src/controllers/walletController.ts
@@ -40,7 +40,7 @@ const walletController = {
       await walletService.addMoneyToWallet(username, amount);
       return c.json({ success: true, data: null });
     } catch (e) {
-      return handleError(c, e, "Failed to add money to wallet", 500);
+      return handleError(c, e, "Failed to add money to wallet", 400);
     }
   },
 };

--- a/services/user-api/src/services/walletService.ts
+++ b/services/user-api/src/services/walletService.ts
@@ -29,9 +29,7 @@ const walletService = {
       const user = await userService.getUserFromId(userId);
       const currentBalance = user.wallet_balance;
       const newBalance = currentBalance + amount;
-      if (newBalance < 0) {
-        throw new Error("User will be left with negative balance");
-      }
+
       await userRepository!.save({ ...user, wallet_balance: newBalance });
     } catch (e) {
       throw new Error("User not found");


### PR DESCRIPTION
Fixed the status code to follow the brightspace announcement:

1. Invalid token:  401 (Unauthorized)
2. Invalid payload (including incorrect login credentials): 400 (Bad request)
3. All other cases: 500 (Internal Server Error)

