### PR TITLE
Hot Fix: Web-ui pass JWT in request header

### DIFF
--- a/services/web-ui/src/lib/Auth/auth.ts
+++ b/services/web-ui/src/lib/Auth/auth.ts
@@ -15,5 +15,5 @@ type AuthHeader = {
 };
 
 export const authHeader = derived(auth, ($auth): AuthHeader | {} => {
-  return $auth.token ? { Authorization: `Bearer ${$auth.token}` } : {};
+  return $auth.token ? { token: $auth.token } : {};
 });

--- a/services/web-ui/src/lib/utils/makeBackendRequest.ts
+++ b/services/web-ui/src/lib/utils/makeBackendRequest.ts
@@ -1,6 +1,4 @@
 import type { Endpoint, FetchOptions, InternalResponse } from "shared-types/dtos";
-import { get } from "svelte/store";
-import { auth } from "../Auth/auth";
 
 // Define your endpoints
 const backendEndpoints = {
@@ -77,7 +75,6 @@ export const makeBackendRequest =
         method: endpoint.requestMethod,
         headers: {
           "Content-Type": "application/json",
-          token: get(auth).token || "",
           ...options.headers,
         },
         body: options.body ? JSON.stringify(options.body) : undefined,

--- a/services/web-ui/src/lib/utils/makeBackendRequest.ts
+++ b/services/web-ui/src/lib/utils/makeBackendRequest.ts
@@ -1,4 +1,6 @@
 import type { Endpoint, FetchOptions, InternalResponse } from "shared-types/dtos";
+import { get } from "svelte/store";
+import { auth } from "../Auth/auth";
 
 // Define your endpoints
 const backendEndpoints = {
@@ -75,6 +77,7 @@ export const makeBackendRequest =
         method: endpoint.requestMethod,
         headers: {
           "Content-Type": "application/json",
+          token: get(auth).token || "",
           ...options.headers,
         },
         body: options.body ? JSON.stringify(options.body) : undefined,


### PR DESCRIPTION
Fixes the frontend requests to backend to pass the JWT in the header with "token" attribute. 

This is due to update in JWT middleware function. Previously frontend passed JWT by "Authorization: Bearer {token}" 