### PR TITLE
fix(OU): fixes problems found during integration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,11 +32,10 @@ services:
       - PORT=3000
       - REDIS_URL=redis://redis:6379
       - ORDER_SERVICE_HOST=http://order-manager:3002
-    container_name: user-api
     networks:
       - day-trading-network
-    ports:
-      - "3000"
+    deploy:
+      replicas: 4
     depends_on:
       order-manager:
         condition: service_started
@@ -89,6 +88,8 @@ services:
         condition: service_healthy
     networks:
       - day-trading-network
+    deploy:
+      replicas: 4
 
   # Order Placement/Cancellation Service
   order-manager:

--- a/packages/shared-models/RedisInstance.ts
+++ b/packages/shared-models/RedisInstance.ts
@@ -46,8 +46,7 @@ class RedisInstance {
 
       for (const [repoKey, schema] of Object.entries(this.schemas)) {
         // repository = new Repository<InferSchema<Entity>>(schema, redisInstance.getClient());
-        let repository = new Repository<Entity>(schema, this.redisClient);
-        repository.createIndex(); // All of our repositorys should expect to be indexed into
+        const repository: Repository<Entity> = await this.createRepository(schema);
         this.repositoryDict[repoKey] = repository;
       }
     } catch (error) {

--- a/packages/shared-models/RedisInstance.ts
+++ b/packages/shared-models/RedisInstance.ts
@@ -1,8 +1,14 @@
-import type { RedisClientType } from 'redis';
-import { createClient } from 'redis';
-import type { Entity } from 'redis-om';
-import { Repository, Schema } from 'redis-om';
-import { ownedStockSchema, stockSchema, stockTransactionSchema, userSchema, walletTransactionSchema } from './redisSchema';
+import type { RedisClientType } from "redis";
+import { createClient } from "redis";
+import type { Entity } from "redis-om";
+import { Repository, Schema } from "redis-om";
+import {
+  ownedStockSchema,
+  stockSchema,
+  stockTransactionSchema,
+  userSchema,
+  walletTransactionSchema,
+} from "./redisSchema";
 
 //Instantiation object
 class RedisInstance {
@@ -12,12 +18,12 @@ class RedisInstance {
   private redisClient: RedisClientType;
   private repositoryDict: Record<string, Repository<Entity>> = {};
   private schemas: Record<string, Schema> = {
-        users: userSchema,
-        ownedStock: ownedStockSchema,
-        stock: stockSchema,
-        walletTransaction: walletTransactionSchema,
-        stockTransaction: stockTransactionSchema
-    };
+    users: userSchema,
+    ownedStock: ownedStockSchema,
+    stock: stockSchema,
+    walletTransaction: walletTransactionSchema,
+    stockTransaction: stockTransactionSchema,
+  };
 
   /**
    *
@@ -37,17 +43,17 @@ class RedisInstance {
       if (!this.redisClient.isOpen) {
         await this.redisClient.connect();
       }
-      
-      for(const [repoKey, schema] of Object.entries(this.schemas)) {
-            // repository = new Repository<InferSchema<Entity>>(schema, redisInstance.getClient());
-            let repository = new Repository<Entity>(schema, this.redisClient);
-            repository.createIndex(); // All of our repositorys should expect to be indexed into 
-            this.repositoryDict[repoKey] = repository;
+
+      for (const [repoKey, schema] of Object.entries(this.schemas)) {
+        // repository = new Repository<InferSchema<Entity>>(schema, redisInstance.getClient());
+        let repository = new Repository<Entity>(schema, this.redisClient);
+        repository.createIndex(); // All of our repositorys should expect to be indexed into
+        this.repositoryDict[repoKey] = repository;
       }
     } catch (error) {
       console.error("Failed to connect to Redis:", error);
       throw error;
-    }      
+    }
   }
 
   /**
@@ -115,12 +121,16 @@ class RedisInstance {
     // Create repository with the schema
     const repository = new Repository<any>(schema, this.redisClient);
 
-    // All of our repositorys should expect to be indexed into
-    await repository.createIndex();
+    // All of our repositories should expect to be indexed.
+    // NOTE: Was getting problems without try catch.
+    try {
+      await repository.createIndex();
+    } catch (error) {
+      console.error("Failed to create index:", error);
+    }
 
     return repository;
   }
-
 }
 
 export { RedisInstance };

--- a/packages/shared-models/redisRepositoryHelper.ts
+++ b/packages/shared-models/redisRepositoryHelper.ts
@@ -1,7 +1,6 @@
-import type { RedisClientType } from 'redis';
-import type { Entity } from 'redis-om';
-import { EntityId, Repository } from 'redis-om';
-
+import type { RedisClientType } from "redis";
+import type { Entity } from "redis-om";
+import { EntityId, Repository } from "redis-om";
 
 /**
  * Takes the given repository, and adds the data into it. The Repository and data passed to it need to have a matching schema in order to work
@@ -10,12 +9,15 @@ import { EntityId, Repository } from 'redis-om';
  * @param data - The data we want to insert into the repository
  * @returns {Promise<string>} - Returns the key in which we inserted our data into.
  */
-export async function addIntoRepository(repository: Repository<Entity>, data: Entity): Promise<string> {
-// Saving the data to the repository
-const record : Entity = await repository.save(data);
+export async function addIntoRepository(
+  repository: Repository<Entity>,
+  data: Entity
+): Promise<string> {
+  // Saving the data to the repository
+  const record: Entity = await repository.save(data);
 
-// Returning the EntityId
-return record[EntityId] as string; // or record.entityId if EntityId is not used directly as a key
+  // Returning the EntityId
+  return record[EntityId] as string; // or record.entityId if EntityId is not used directly as a key
 }
 
 /**
@@ -24,9 +26,12 @@ return record[EntityId] as string; // or record.entityId if EntityId is not used
  * @param key - The key for the data we want to retrieve from the repository
  * @returns {Promise<Entity>} - Returns the data stored at that key.
  */
-export async function getFromRepository(repository: Repository<Entity>, key: string): Promise<Entity> {
-let data : Entity | Entity[] = await repository.fetch(key);
-return data;
+export async function getFromRepository(
+  repository: Repository<Entity>,
+  key: string
+): Promise<Entity> {
+  let data: Entity | Entity[] = await repository.fetch(key);
+  return data;
 }
 
 /**
@@ -35,17 +40,20 @@ return data;
  * @param key - The key for the data we want to retrieve from the repository
  * @returns {Promise<void>} - Returns nothing.
  */
-export async function removeFromRepository(repository: Repository<Entity>, key: string): Promise<void> {
-await repository.remove(key);
+export async function removeFromRepository(
+  repository: Repository<Entity>,
+  key: string
+): Promise<void> {
+  await repository.remove(key);
 }
 
 /**
  * Gets the key from the entity. This is a helper function to get the key from the entity
  * @param entity - The entity we want to get the key from
- * @returns 
+ * @returns
  */
 export async function getKeyFromEntity(entity: Entity): Promise<string> {
-    return entity[EntityId] as string;
+  return entity[EntityId] as string;
 }
 
 /**
@@ -55,9 +63,13 @@ export async function getKeyFromEntity(entity: Entity): Promise<string> {
  * @param amountToChange - The amount we want to change the current_quantity by
  * @returns {Promise<boolean>} - Returns true if the stock was successfully updated, false if the stock would be decremented below 0 or had a error
  */
-export async function ownedStockAtomicUpdate(redisInstance: RedisClientType, stockOwnedKey: string, amountToChange: number): Promise<boolean> {
-    // If a true is returned its actually a 1, if false its null 
-    const luaScript = `
+export async function ownedStockAtomicUpdate(
+  redisInstance: RedisClientType,
+  stockOwnedKey: string,
+  amountToChange: number
+): Promise<boolean> {
+  // If a true is returned its actually a 1, if false its null
+  const luaScript = `
     local data = redis.call('JSON.GET', KEYS[1])
     local jsonData = cjson.decode(data)
     local amountToChange = tonumber(ARGV[1])
@@ -69,53 +81,135 @@ export async function ownedStockAtomicUpdate(redisInstance: RedisClientType, sto
         redis.call('JSON.SET', KEYS[1], '.', cjson.encode(jsonData))
         return true    
     end
-    `; 
+    `;
 
-    try {
-        //Not sure if I can remove any, also gotta add users: because redis-om adds it
-        // This is a finnecky thing, but it works and does it atomically
-        const result = await redisInstance.eval(luaScript, { keys: ["owned_stocks:" + stockOwnedKey], arguments: [amountToChange.toString()] } as any); // Args need to be passed as strings
-        // console.log(result);
-        return result !== null;
-    } catch (error) {
-        console.error("Error executing Lua script:", error);
-        return false;
-    }
+  try {
+    //Not sure if I can remove any, also gotta add users: because redis-om adds it
+    // This is a finnecky thing, but it works and does it atomically
+    const result = await redisInstance.eval(luaScript, {
+      keys: ["owned_stocks:" + stockOwnedKey],
+      arguments: [amountToChange.toString()],
+    } as any); // Args need to be passed as strings
+    // console.log(result);
+    return result !== null;
+  } catch (error) {
+    console.error("Error executing Lua script:", error);
+    return false;
+  }
 }
 
 /**
- * This function updates a user's wallet balance atomically. This is done by adding the amountToChange to the wallet balance of the user object.
+ * This function updates a user's wallet balance atomically.
+ * This is done by adding the amountToChange to the wallet balance of the user object.
+ *
+ * NOTE: Withdrawals are not allowed if the wallet is locked. See `userWalletDeductAndUnlockAtomicUpdate` for a function that allows withdrawals when the wallet is locked.
+ *
  * @param redisInstance - The redis client instance
  * @param userKey - The key of the user object we want to update
  * @param amountToChange - The amount we want to change the wallet balance by
  * @returns {Promise<boolean>} - Returns true if the wallet was successfully updated, false if the wallet would be decremented below 0, is locked and we are subtracting, or had a error
  */
-export async function userWalletAtomicUpdate(redisInstance: RedisClientType, userKey: string, amountToChange: number): Promise<boolean> {
-    // If a true is returned its actually a 1, if false its null 
-    const luaScript = `
+export async function userWalletAtomicUpdate(
+  redisInstance: RedisClientType,
+  userKey: string,
+  amountToChange: number
+): Promise<boolean> {
+  const luaScript = `
     local data = redis.call('JSON.GET', KEYS[1])
+    if not data then
+        return false -- Key doesn't exist
+    end
+    
     local jsonData = cjson.decode(data)
     local amountToChange = tonumber(ARGV[1])
 
-    if ((jsonData.is_locked) and (amountToChange < 0)) or (jsonData.wallet_balance + amountToChange < 0) then
+    -- Check if withdrawal is allowed
+    if (jsonData.is_locked and amountToChange < 0) or (jsonData.wallet_balance + amountToChange < 0) then
         return false
     else
         jsonData.wallet_balance = jsonData.wallet_balance + amountToChange
         redis.call('JSON.SET', KEYS[1], '.', cjson.encode(jsonData))
         return true    
     end
-    `; 
+    `;
 
-    try {
-        //Not sure if I can remove any, also gotta add users: because redis-om adds it
-        // This is a finnecky thing, but it works and does it atomically
-        const result = await redisInstance.eval(luaScript, { keys: ["users:" + userKey], arguments: [amountToChange.toString()] } as any); // Args need to be passed as strings
-        // console.log(result);
-        return result !== null;
-    } catch (error) {
-        console.error("Error executing Lua script:", error);
-        return false;
-    }
+  try {
+    // Redis-OM prefixes keys with "users:", so we add it to the key
+    const result = await redisInstance.eval(luaScript, {
+      keys: ["users:" + userKey],
+      arguments: [amountToChange.toString()],
+    });
+
+    // Redis Lua returns 1 for true and nil for false, which becomes null in JS
+    return result !== null;
+  } catch (error) {
+    console.error("Error executing Lua script:", error);
+    return false;
+  }
+}
+
+/**
+ * This function deducts money from a user's wallet and unlocks it atomically.
+ * It will first check if the wallet has enough funds before performing the deduction and unlock.
+ *
+ * NOTE: This function will succeed even if the wallet is locked - it's specifically designed to
+ * perform the deduction and unlock in one atomic operation.
+ * 
+ * This function is needed because withdrawals are not allowed if the wallet is locked. But, 
+ * we need to update the user wallet before they can buy more stocks. And the moment we unlock
+ * the user's wallet, they can buy more stocks. So, we need to do the deduction and unlock in one 
+ * atomic operation.
+ *
+ * @param redisInstance - The redis client instance
+ * @param userKey - The key of the user object we want to update
+ * @param amountToDeduct - The amount we want to deduct from the wallet balance (should be positive)
+ * @returns {Promise<boolean>} - Returns true if the deduction and unlock was successful, false if the wallet would be decremented below 0 or had an error
+ */
+export async function userWalletDeductAndUnlockAtomicUpdate(
+  redisInstance: RedisClientType,
+  userKey: string,
+  amountToDeduct: number
+): Promise<boolean> {
+  // Ensure amountToDeduct is positive for clarity in the function's purpose
+  if (amountToDeduct < 0) {
+    console.error("amountToDeduct must be positive");
+    return false;
+  }
+
+  const luaScript = `
+    local data = redis.call('JSON.GET', KEYS[1])
+    if not data then
+        return false -- Key doesn't exist
+    end
+    
+    local jsonData = cjson.decode(data)
+    local amountToDeduct = tonumber(ARGV[1])
+
+    -- Check if deduction is allowed (only check balance, ignore lock status)
+    if jsonData.wallet_balance - amountToDeduct < 0 then
+        return false
+    else
+        -- Deduct amount and unlock wallet in one operation
+        jsonData.wallet_balance = jsonData.wallet_balance - amountToDeduct
+        jsonData.is_locked = false
+        redis.call('JSON.SET', KEYS[1], '.', cjson.encode(jsonData))
+        return true    
+    end
+    `;
+
+  try {
+    // Redis-OM prefixes keys with "users:", so we add it to the key
+    const result = await redisInstance.eval(luaScript, {
+      keys: ["users:" + userKey],
+      arguments: [amountToDeduct.toString()],
+    });
+
+    // Redis Lua returns 1 for true and nil for false, which becomes null in JS
+    return result !== null;
+  } catch (error) {
+    console.error("Error executing Lua script:", error);
+    return false;
+  }
 }
 
 /**
@@ -125,9 +219,12 @@ export async function userWalletAtomicUpdate(redisInstance: RedisClientType, use
  * @param user_key - The key of the user we want to lock
  * @returns {Promise<boolean>} - Returns true if the user was successfully locked, false if the user was already locked or had a error
  */
-export async function lockUserWallet(redisInstance: RedisClientType, user_key: string): Promise<boolean> {
-    // If a true is returned its actually a 1, if false its null 
-    const luaScript = `
+export async function lockUserWallet(
+  redisInstance: RedisClientType,
+  user_key: string
+): Promise<boolean> {
+  // If a true is returned its actually a 1, if false its null
+  const luaScript = `
     local data = redis.call('JSON.GET', KEYS[1])
     local jsonData = cjson.decode(data)
 
@@ -138,18 +235,21 @@ export async function lockUserWallet(redisInstance: RedisClientType, user_key: s
         redis.call('JSON.SET', KEYS[1], '.', cjson.encode(jsonData))
         return true    
     end
-    `; 
+    `;
 
-    try {
-        // Not sure if I can remove any, also gotta add users: because redis-om adds it
-        // This is a finnecky thing, but it works and does it atomically
-        const result = await redisInstance.eval(luaScript, { keys: ["users:" + user_key], arguments: [] } as any); 
-        // console.log(result);
-        return result !== null;
-    } catch (error) {
-        console.error("Error executing Lua script:", error);
-        return false;
-    }
+  try {
+    // Not sure if I can remove any, also gotta add users: because redis-om adds it
+    // This is a finnecky thing, but it works and does it atomically
+    const result = await redisInstance.eval(luaScript, {
+      keys: ["users:" + user_key],
+      arguments: [],
+    } as any);
+    // console.log(result);
+    return result !== null;
+  } catch (error) {
+    console.error("Error executing Lua script:", error);
+    return false;
+  }
 }
 
 /**
@@ -159,8 +259,7 @@ export async function lockUserWallet(redisInstance: RedisClientType, user_key: s
  * @param key - The key of the user we want to unlock
  */
 export async function unlockUserWallet(repository: Repository<Entity>, key: string): Promise<void> {
-    let user = await repository.fetch(key);
-    user.is_locked = false;
-    repository.save(user);
+  let user = await repository.fetch(key);
+  user.is_locked = false;
+  await repository.save(user);
 }
-

--- a/packages/shared-models/redisRepositoryHelper.ts
+++ b/packages/shared-models/redisRepositoryHelper.ts
@@ -156,9 +156,9 @@ export async function userWalletAtomicUpdate(
  * perform the deduction and unlock in one atomic operation.
  * 
  * This function is needed because withdrawals are not allowed if the wallet is locked. But, 
- * we need to update the user wallet before they can buy more stocks. And the moment we unlock
- * the user's wallet, they can buy more stocks. So, we need to do the deduction and unlock in one 
- * atomic operation.
+ * the moment we unlock the user's wallet, they can buy more stocks. However, we need to 
+ * update the user wallet before they are allowed to buy more stocks (to avoid race conditions). 
+ * So, we need to do the deduction and unlock in one atomic operation.
  *
  * @param redisInstance - The redis client instance
  * @param userKey - The key of the user object we want to update

--- a/services/gateway/nginx.conf
+++ b/services/gateway/nginx.conf
@@ -1,3 +1,17 @@
+upstream user_api_backend {
+    server user-api:3000;
+    server user-api:3000;
+    server user-api:3000;
+    server user-api:3000;
+}
+
+upstream auth_backend {
+    server auth:3000;
+    server auth:3000;
+    server auth:3000;
+    server auth:3000;
+}
+
 server {
     listen 80;
     server_name localhost;
@@ -14,19 +28,19 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_pass http://user-api:3000/transaction/;
+        proxy_pass http://user_api_backend/transaction/;
     }
     location /engine/ {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_pass http://user-api:3000/engine/;
+        proxy_pass http://user_api_backend/engine/;
     }
     location /setup/ {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_pass http://user-api:3000/setup/;
+        proxy_pass http://user_api_backend/setup/;
     }
 
     # Reverse proxy to stock-price service
@@ -43,6 +57,6 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_pass http://auth:3000/authentication/;
+        proxy_pass http://auth_backend/authentication/;
     }
 }

--- a/services/order-update/src/handlers/orderUpdateHandler.ts
+++ b/services/order-update/src/handlers/orderUpdateHandler.ts
@@ -49,16 +49,16 @@ export default {
   handleSaleUpdate: async (data: SalesUpdateData) => {
     // TODO: Add payload check? If so, type is Partial<...>
 
-    OrderUpdateService.handleSaleUpdate(data);
+    await OrderUpdateService.handleSaleUpdate(data);
   },
 
   handleBuyCompletion: async (data: BuyCompleteData) => {
     // TODO: Add payload check? If so, type is Partial<...>
 
     if (data.success) {
-      OrderUpdateService.handleBuyCompletion(data.data);
+      await OrderUpdateService.handleBuyCompletion(data.data);
     } else {
-      OrderUpdateService.handleFailedBuyCompletion(data.data);
+      await OrderUpdateService.handleFailedBuyCompletion(data.data);
     }
   },
 
@@ -66,7 +66,7 @@ export default {
     // TODO: Add payload check? If so, type is Partial<...>
 
     if (data.success) {
-      OrderUpdateService.handleCancellation(data.data);
+      await OrderUpdateService.handleCancellation(data.data);
     } else {
       console.error("Failed to cancel order:", data.data);
     }


### PR DESCRIPTION
Changes
- added try catch to `redis.createIndex` (was getting problems without it)
- create `userWalletDeductAndUnlockAtomicUpdate` [1]
- fix errors not being caught in OU consumers
- fix buy completion error & logics [1]

[1] An additional function for deducting the wallet & unlock in one operation was needed because of a dilemma within the buy completion logic. With `userWalletAtomicUpdate`, withdrawals are not allowed if the wallet is locked. But, the moment we unlock the user's wallet, they can buy more stocks. However, we need to update the user wallet before they are allowed to buy more stocks (to avoid race conditions). So, we need to do the deduction and unlock in one atomic operation.