### PR TITLE
feat: scale out auth service to 4 instances

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,6 +88,8 @@ services:
         condition: service_healthy
     networks:
       - day-trading-network
+    deploy:
+      replicas: 4
 
   # Order Placement/Cancellation Service
   order-manager:

--- a/services/gateway/nginx.conf
+++ b/services/gateway/nginx.conf
@@ -5,6 +5,13 @@ upstream user_api_backend {
     server user-api:3000;
 }
 
+upstream auth_backend {
+    server auth:3000;
+    server auth:3000;
+    server auth:3000;
+    server auth:3000;
+}
+
 server {
     listen 80;
     server_name localhost;
@@ -50,6 +57,6 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_pass http://auth:3000/authentication/;
+        proxy_pass http://auth_backend/authentication/;
     }
 }


### PR DESCRIPTION
Horizontally scales the auth service to 4 instances. Can be tweaked as we do final load testing. 