### PR TITLE
ME: `u64` for Stock Quantity

### DIFF
--- a/.vscode/project.code-workspace
+++ b/.vscode/project.code-workspace
@@ -51,6 +51,10 @@
         {
             "name": "Order Placement/Cancellation Service",
             "path": "../services/order-manager"
+        },
+        {
+            "name": "Stock Price Service",
+            "path": "../services/stock-price"
         }
     ],
     "settings": {

--- a/services/matching-engine/README.md
+++ b/services/matching-engine/README.md
@@ -27,7 +27,7 @@ The exchange is `order_exchange`.
 ```rs
 pub struct MarketBuyRequest {
     pub stock_id: String,
-    pub quantity: u32,
+    pub quantity: u64,
     pub stock_tx_id: String,
     pub budget: f64,
     pub user_name: String,
@@ -39,7 +39,7 @@ pub struct MarketBuyRequest {
 pub struct LimitSellRequest {
     pub stock_id: String,
     pub stock_name: String,
-    pub quantity: u32,
+    pub quantity: u64,
     pub price: f64,
     pub stock_tx_id: String,
     pub user_name: String,
@@ -51,7 +51,7 @@ pub struct LimitSellRequest {
 ```rs
 pub struct LimitSellCancelRequest {
     pub stock_id: String,
-    pub quantity: u32,
+    pub quantity: u64,
     pub price: f64,
     pub stock_tx_id: String,
 }
@@ -72,7 +72,7 @@ pub struct MarketBuyResponse {
 pub struct MarketBuyData {
     pub stock_id: String,
     pub stock_tx_id: String,
-    pub quantity: Option<u32>, // None if success is false
+    pub quantity: Option<u64>, // None if success is false
     pub price_total: Option<f64>, // None if success is false
 }
 ```
@@ -89,9 +89,9 @@ pub struct LimitSellCancelData {
     pub stock_id: String,
     pub stock_tx_id: String,
     pub partially_sold: bool,
-    pub ori_quantity: u32,
-    pub cur_quantity: u32,
-    pub sold_quantity: u32,
+    pub ori_quantity: u64,
+    pub cur_quantity: u64,
+    pub sold_quantity: u64,
     pub price: f64,
 }
 ```
@@ -100,8 +100,8 @@ pub struct LimitSellCancelData {
 ```rs
 pub struct OrderUpdate {
     pub stock_id: String,
-    pub sold_quantity: u32,
-    pub remaining_quantity: u32,
+    pub sold_quantity: u64,
+    pub remaining_quantity: u64,
     pub price: f64,
     pub stock_tx_id: String,
     pub user_name: String,

--- a/services/matching-engine/src/consumers.rs
+++ b/services/matching-engine/src/consumers.rs
@@ -64,7 +64,7 @@ impl OrderConsumer {
         let mut state = self.state.write().await;
 
         // Total number of shares on sale excluding those from the user requesting the buy order
-        let available_shares: u32 = state
+        let available_shares: u64 = state
             .matching_pq
             .get_all_orders(&request.stock_id)
             .iter()

--- a/services/matching-engine/src/matching_pq.rs
+++ b/services/matching-engine/src/matching_pq.rs
@@ -7,8 +7,8 @@ pub struct SellOrder {
     pub stock_name: String,
     pub stock_tx_id: String,
     pub partially_sold: bool,
-    pub ori_quantity: u32,
-    pub cur_quantity: u32,
+    pub ori_quantity: u64,
+    pub cur_quantity: u64,
     pub price: f64,
     pub user_name: String, 
 }

--- a/services/matching-engine/src/models.rs
+++ b/services/matching-engine/src/models.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 // Stock prices types
-#[derive(Serialize, Debug)]
+#[derive(Serialize, Debug, Clone)]
 pub struct StockPrice {
     pub stock_id: String,
     pub stock_name: Option<String>, // None/null if stock is no longer available
@@ -12,7 +12,7 @@ pub struct StockPrice {
 #[derive(Deserialize, Debug)]
 pub struct MarketBuyRequest {
     pub stock_id: String,
-    pub quantity: u32,
+    pub quantity: u64,
     pub stock_tx_id: String,
     pub budget: f64,
     pub user_name: String,
@@ -28,7 +28,7 @@ pub struct MarketBuyResponse {
 pub struct MarketBuyData {
     pub stock_id: String,
     pub stock_tx_id: String,
-    pub quantity: Option<u32>, // None if success is false
+    pub quantity: Option<u64>, // None if success is false
     pub price_total: Option<f64>, // None if success is false
 }
 
@@ -37,7 +37,7 @@ pub struct MarketBuyData {
 pub struct LimitSellRequest {
     pub stock_id: String,
     pub stock_name: String,
-    pub quantity: u32,
+    pub quantity: u64,
     pub price: f64,
     pub stock_tx_id: String,
     pub user_name: String,
@@ -45,7 +45,7 @@ pub struct LimitSellRequest {
 #[derive(Deserialize, Debug)]
 pub struct LimitSellCancelRequest {
     pub stock_id: String,
-    pub quantity: u32,
+    pub quantity: u64,
     pub price: f64,
     pub stock_tx_id: String,
 }
@@ -66,17 +66,17 @@ pub struct LimitSellCancelData {
     pub stock_id: String,
     pub stock_tx_id: String,
     pub partially_sold: bool,
-    pub ori_quantity: u32,
-    pub cur_quantity: u32,
-    pub sold_quantity: u32,
+    pub ori_quantity: u64,
+    pub cur_quantity: u64,
+    pub sold_quantity: u64,
     pub price: f64,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct OrderUpdate {
     pub stock_id: String,
-    pub sold_quantity: u32,
-    pub remaining_quantity: u32,
+    pub sold_quantity: u64,
+    pub remaining_quantity: u64,
     pub price: f64,
     pub stock_tx_id: String,
     pub user_name: String,


### PR DESCRIPTION
Change the ME to use `u64` for stock quantity because the JMeter test script sends in numbers beyond what `u32` can store. 

Specifically, the JMeter script sends in requests like the following
```json
{
    "stock_id": "a5561829-cd06-4b82-b267-eb231a8e506d",
    "stock_name": "Apple",
    "quantity": 15509763000,
    "price": 140,
    "stock_tx_id": "d7dfdb1f-1085-4d60-841c-372f9dcc5a52",
    "user_name": "VanguardETF"
}
```

Since $15509763000$ exceed the limit of `u32`, this order fails with the previous implementation of ME. 