### PR TITLE
Concurrent message processing in OU worker

### DIFF
--- a/services/order-update/src/consumers/orderUpdateConsumer.ts
+++ b/services/order-update/src/consumers/orderUpdateConsumer.ts
@@ -6,8 +6,12 @@ const DEFAULT_RABBITMQ_URL = "amqp://guest:guest@localhost:5672";
 const EXCHANGE_NAME = "order_update_exchange";
 const QUEUE_NAME = "order_update_queue";
 const ROUTING_KEYS = ["order.sale_update", "order.buy_completed", "order.cancelled"];
+const DEFAULT_MAX_CONCURRENT_MSG = 100;
 
-export async function startOrderUpdateConsumer(rabbitMQUrl = DEFAULT_RABBITMQ_URL) {
+export async function startOrderUpdateConsumer(
+  rabbitMQUrl = DEFAULT_RABBITMQ_URL,
+  maxConcurrentMsg = DEFAULT_MAX_CONCURRENT_MSG
+) {
   try {
     const connection = await amqp.connect(rabbitMQUrl);
     const channel = await connection.createChannel();
@@ -21,54 +25,78 @@ export async function startOrderUpdateConsumer(rabbitMQUrl = DEFAULT_RABBITMQ_UR
       await channel.bindQueue(QUEUE_NAME, EXCHANGE_NAME, routingKey);
     }
 
-    channel.prefetch(1); // Fair dispatch to allow multiple consumers (Work Queue)
+    // Allow prefetch > 1 to allow more messages to be processed concurrently
+    channel.prefetch(maxConcurrentMsg);
 
-    logger.info("Order Update Service waiting for messages...");
+    // Track in-flight promises to limit concurrency
+    const inFlightPromises = new Set();
+
+    logger.info(
+      `Order Update Service waiting for messages (max concurrent: ${maxConcurrentMsg})...`
+    );
 
     await channel.consume(
       QUEUE_NAME,
-      async (msg) => {
+      (msg) => {
         if (!msg) return;
 
-        try {
-          const content = JSON.parse(msg.content.toString());
-          const routingKey = msg.fields.routingKey;
+        // Function to process one message
+        const processMessage = async () => {
+          try {
+            const content = JSON.parse(msg.content.toString());
+            const routingKey = msg.fields.routingKey;
 
-          logger.debug(`Received message with routing key: ${routingKey}`);
-          logger.debug(`Message content: ${content}`);
+            logger.debug(`Processing message with routing key: ${routingKey}`);
 
-          switch (routingKey) {
-            case "order.sale_update":
-              await OrderUpdateHandler.handleSaleUpdate(content);
-              break;
+            switch (routingKey) {
+              case "order.sale_update":
+                await OrderUpdateHandler.handleSaleUpdate(content);
+                break;
 
-            case "order.buy_completed":
-              await OrderUpdateHandler.handleBuyCompletion(content);
-              break;
+              case "order.buy_completed":
+                await OrderUpdateHandler.handleBuyCompletion(content);
+                break;
 
-            case "order.cancelled":
-              await OrderUpdateHandler.handleCancellation(content);
-              break;
+              case "order.cancelled":
+                await OrderUpdateHandler.handleCancellation(content);
+                break;
 
-            default:
-              logger.warn(`Unknown routing key: ${routingKey}`);
-              channel.nack(msg); // Reject invalid messages
-              return;
+              default:
+                logger.warn(`Unknown routing key: ${routingKey}`);
+                channel.nack(msg, false, false); // Reject invalid messages
+                return;
+            }
+
+            channel.ack(msg);
+            logger.debug(`Successfully processed message with routing key: ${routingKey}`);
+          } catch (error) {
+            logger.error("Message processing failed:", error);
+            channel.nack(msg, false, false); // Dead-letter handling
+          } finally {
+            // Remove this promise from the tracking set when done
+            inFlightPromises.delete(processingPromise);
           }
+        };
 
-          channel.ack(msg);
-        } catch (error) {
-          logger.error("Message processing failed:", error);
-          channel.nack(msg, false, false); // Dead-letter handling
-        }
+        const processingPromise = processMessage();
+        inFlightPromises.add(processingPromise);
       },
       { noAck: false }
     );
 
-    // Graceful shutdown
+    // Graceful shutdown handling with proper cleanup
     process.once("SIGINT", async () => {
+      logger.info("Shutting down Order Update Service...");
+
+      // Wait for in-flight messages to complete processing
+      if (inFlightPromises.size > 0) {
+        logger.info(`Waiting for ${inFlightPromises.size} in-flight messages to complete...`);
+        await Promise.allSettled(inFlightPromises);
+      }
+
       await channel.close();
       await connection.close();
+      logger.info("Order Update Service shutdown complete");
       process.exit(0);
     });
   } catch (error) {

--- a/services/order-update/src/consumers/orderUpdateConsumer.ts
+++ b/services/order-update/src/consumers/orderUpdateConsumer.ts
@@ -6,7 +6,7 @@ const DEFAULT_RABBITMQ_URL = "amqp://guest:guest@localhost:5672";
 const EXCHANGE_NAME = "order_update_exchange";
 const QUEUE_NAME = "order_update_queue";
 const ROUTING_KEYS = ["order.sale_update", "order.buy_completed", "order.cancelled"];
-const DEFAULT_MAX_CONCURRENT_MSG = 100;
+const DEFAULT_MAX_CONCURRENT_MSG = 10;
 
 export async function startOrderUpdateConsumer(
   rabbitMQUrl = DEFAULT_RABBITMQ_URL,

--- a/services/order-update/src/index.ts
+++ b/services/order-update/src/index.ts
@@ -1,6 +1,10 @@
 import { startOrderUpdateConsumer } from "@/consumers/orderUpdateConsumer";
 import logger from "./utils/logger";
 
+const maxConcurrentMsgs = Bun.env.MAX_CONCURRENT_MSGS
+  ? parseInt(Bun.env.MAX_CONCURRENT_MSGS)
+  : undefined;
+
 const rabbitPort = Bun.env.RABBIT_PORT || 5672;
 const rabbitHost = Bun.env.RABBIT_HOST || "localhost";
 const rabbitUser = Bun.env.RABBIT_USER || "guest";
@@ -10,4 +14,4 @@ const rabbitUrl = `amqp://${rabbitUser}:${rabbitPassword}@${rabbitHost}:${rabbit
 
 logger.info(`Order Update Service have started.`);
 
-await startOrderUpdateConsumer(rabbitUrl);
+await startOrderUpdateConsumer(rabbitUrl, maxConcurrentMsgs);


### PR DESCRIPTION
Changed prefetch to be larger than 1 to allow concurrent message processing.

Originally, it was 1 because it ensures fair dispatch of messages to workers, but this might not be necessary.

Please also check if messages are being dispatched fairly as well for this review. 