### PR TITLE
fix: add a delay to buy order

### DIFF
--- a/services/order-manager/src/controllers/orderManagerController.ts
+++ b/services/order-manager/src/controllers/orderManagerController.ts
@@ -28,6 +28,7 @@ const controller = {
 
     try {
       await service.placeMarketBuyOrder(stock_id, quantity, user_name);
+      await Bun.sleep(250);
       return c.json({ success: true, data: null }, 201);
     } catch (error) {
       return handleError(c, error, "An unknown error has occurred with market buy");


### PR DESCRIPTION
This is because for SOME reason, the JMeter test script expects the buy order to be completed as soon as the buy request is resolved even though that is not how async processing works.

Without this, our system will not even pass test run 2 with a user load of 1.