### PR TITLE
Order Manager Wait For Buy Completion Before Returning 

### DIFF
--- a/services/order-manager/src/controllers/orderManagerController.ts
+++ b/services/order-manager/src/controllers/orderManagerController.ts
@@ -27,8 +27,10 @@ const controller = {
     const { stock_id, quantity, user_name } = await c.req.json();
 
     try {
-      await service.placeMarketBuyOrder(stock_id, quantity, user_name);
-      await Bun.sleep(250);
+      const stockTxId = await service.placeMarketBuyOrder(stock_id, quantity, user_name);
+
+      await service.waitForBuyCompletion(stockTxId);
+
       return c.json({ success: true, data: null }, 201);
     } catch (error) {
       return handleError(c, error, "An unknown error has occurred with market buy");


### PR DESCRIPTION
As promised, this PR makes it so the Order Manager will not response and terminate a buy order request until the buy order has been processed by ME and OU or it has timed out (exceeds 20s). 

This is currently implemented using a polling loop, checking the transaction JSON every 250ms (can be changed). Hence, there are definitely some overhead with this feature hitting the DB. 

In the future, we can consider using pub/sub key change event in Redis, but that has its own overhead as well. 



### Claude code for using Redis Pub/Sub
```ts
import { createClient } from 'redis';

async function watchMultipleRedisKeys() {
  const client = createClient();
  const subscriber = client.duplicate();
  
  try {
    await client.connect();
    await subscriber.connect();
    
    // Enable keyspace notifications
    await client.configSet('notify-keyspace-events', 'KEA');
    
    const keysToWatch = ['key1', 'key2', 'key3'];
    const channels = keysToWatch.map(key => `__keyspace@0__:${key}`);
    
    // Subscribe to multiple channels
    for (const channel of channels) {
      await subscriber.subscribe(channel, (message, channelName) => {
        // Extract the key name from the channel
        const keyName = channelName.split(':')[1];
        console.log(`Key '${keyName}' was modified with operation: ${message}`);
        
        // Your operation here
      });
    }
    
    console.log(`Watching for changes to keys: ${keysToWatch.join(', ')}`);
    
    // To unsubscribe from a specific channel later:
    // This can be called from anywhere in your code when needed
    const unsubscribeFromKey = async (keyName: string) => {
      const channel = `__keyspace@0__:${keyName}`;
      await subscriber.unsubscribe(channel);
      console.log(`Stopped watching key: ${keyName}`);
    };
    
    // Example: Unsubscribe from 'key2' after 10 seconds
    setTimeout(async () => {
      await unsubscribeFromKey('key2');
    }, 10000);
    
    // Example: Unsubscribe from all channels after 30 seconds
    setTimeout(async () => {
      for (const key of keysToWatch) {
        try {
          await unsubscribeFromKey(key);
        } catch (err) {
          // Handle case where we might have already unsubscribed
          console.log(`Already unsubscribed from ${key} or error: ${err}`);
        }
      }
      
      // Close connections when done
      await subscriber.quit();
      await client.quit();
      console.log('All connections closed');
    }, 30000);
    
  } catch (error) {
    console.error('Error setting up Redis key watching:', error);
    
    // Cleanup
    await subscriber.quit();
    await client.quit();
  }
}

watchMultipleRedisKeys();
```