### PR TITLE
Requests Queue in Nginx

### DIFF
--- a/services/gateway/app.conf
+++ b/services/gateway/app.conf
@@ -1,25 +1,11 @@
 
 
 upstream user_api_backend {
-    # least_conn;
     server user-api:3000;
-    # server user-api:3000 max_fails=5 fail_timeout=2s;
-    # server user-api:3000 max_fails=5 fail_timeout=2s;
-    # server user-api:3000 max_fails=5 fail_timeout=2s;
-    # server user-api:3000 backup;
-    # server user-api:3000 backup;
 }
 
 upstream auth_backend {
-    # least_conn;
     server auth:3000;
-    # server auth:3000 max_fails=5 fail_timeout=2s;
-    # server auth:3000 max_fails=5 fail_timeout=2s;
-    # server auth:3000 max_fails=5 fail_timeout=2s;
-    # server auth:3000 max_fails=5 fail_timeout=2s;
-    # server auth:3000 max_fails=5 fail_timeout=2s;
-    # server auth:3000 max_fails=5 fail_timeout=2s;
-    # server auth:3000 max_fails=5 fail_timeout=2s;
 }
 
 server {
@@ -39,17 +25,25 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_pass http://user_api_backend/transaction/;
+
+        # https://blog.nginx.org/blog/rate-limiting-nginx
+        # if request limited: will wait 3 seconds in queue before retrying request
+        # The burst parameter in limit_req defines how many extra requests can be queued temporarily beyond the configured rate limit before requests start getting rejected.
+        # example: If more than 3000 + 5000 = 8000 requests arrive in 1 second, the extra requests are rejected (503 Too Many Requests).
+        limit_req zone=request_limit burst=5000 delay=3;
     }
     location /engine/ {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        limit_req zone=request_limit burst=5000 delay=3;
         proxy_pass http://user_api_backend/engine/;
     }
     location /setup/ {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        limit_req zone=request_limit burst=5000 delay=3;
         proxy_pass http://user_api_backend/setup/;
     }
 
@@ -59,6 +53,7 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        limit_req zone=request_limit burst=5000 delay=3;
         proxy_pass http://stock-price:3000/stockPrices;
     }
 
@@ -67,6 +62,7 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        limit_req zone=request_limit burst=5000 delay=3;
         proxy_pass http://auth_backend/authentication/;
     }
 }

--- a/services/gateway/nginx.conf
+++ b/services/gateway/nginx.conf
@@ -19,7 +19,6 @@ http {
     server_tokens off;
     client_max_body_size 25m;
 
-        
     # Buffer Settings
     client_body_buffer_size 128k;
     client_header_buffer_size 1k;
@@ -34,6 +33,10 @@ http {
     # Logging Settings
     access_log /var/log/nginx/access.log;
     error_log /var/log/nginx/error.log warn;
+
+    # https://blog.nginx.org/blog/rate-limiting-nginx
+    # Rate limit (3000 req/sec, queued requests stored in 10MB shared memory)
+    limit_req_zone $binary_remote_addr zone=request_limit:10m rate=3000r/s;
 
     include /etc/nginx/conf.d/*.conf;  # Include server configurations
 }


### PR DESCRIPTION
Turns out Nginx has a way to do rate limiting and putting requests in a queue, without Ngninx Plus.

https://blog.nginx.org/blog/rate-limiting-nginx